### PR TITLE
Fixed correlating env var "USERNAME" with windows env var USERNAME

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ require('dotenv').config();
 
 console.log(figlet.textSync('BitbuckUp').blue);
 console.log('');
-if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.USERNAME) {
+if (!process.env.CLIENT_ID || !process.env.CLIENT_SECRET || !process.env.USERNAMES) {
   console.log('.env file is missing or incomplete'.bold.red);
   console.log(`Make sure your .env file exists and contains the following variables:
 CLIENT_ID=12345
 CLIENT_SECRET=abcdef
-USERNAME=user`)
+USERNAMES=user`)
   process.exit(1);
 }
 
@@ -25,12 +25,12 @@ if (!shell.which('git')) {
   process.exit(1);
 }
 
-const users = process.env.USERNAME.split(/,\s*/).map(value => value.trim());
+const users = process.env.USERNAMES.split(/,\s*/).map(value => value.trim());
 
 const baseUrl = `https://api.bitbucket.org/2.0/`
 const authUrl = 'https://bitbucket.org/site/oauth2/access_token';
 // const authUrl = 'https://req.dev.so';
-// const repoUrl = `${baseUrl}repositories/${process.env.USERNAME}`;
+// const repoUrl = `${baseUrl}repositories/${process.env.USERNAMES}`;
 
 const authData = 'grant_type=client_credentials';
 const authHeader = {

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Create a `.env` file in the folder you want the backups to be created, containin
 ```bash
 CLIENT_ID=12345
 CLIENT_SECRET=abcdef
-USERNAME=user1,user2,team1,team2
+USERNAMES=user1,user2,team1,team2
 ```
 
 Then open a terminal with that folder and run:


### PR DESCRIPTION
Used it with windows 10 and got access denied, because the script used my windows 10 username and not the variable I provided in the .env file.
Changing it to "USERNAMS" is semantically correct, because you can provide more than one username and it fixes the issue with windows username.